### PR TITLE
Fix ASN parsing on 32-bit platforms

### DIFF
--- a/cmd/gortr/gortr.go
+++ b/cmd/gortr/gortr.go
@@ -148,7 +148,7 @@ func processData(roalistjson *prefixfile.ROAList) ([]rtr.ROA, int, int, int) {
 	for _, v := range roalistjson.Data {
 		_, prefix, _ := net.ParseCIDR(v.Prefix)
 		asnStr := v.ASN[2:len(v.ASN)]
-		asnInt, _ := strconv.Atoi(asnStr)
+		asnInt, _ := strconv.ParseUint(asnStr, 10, 32)
 		asn := uint32(asnInt)
 
 		count++


### PR DESCRIPTION
ASNs are 32-bit unsigned integers. However, `strconv.Atoi` will return `int`s, which are 32-bit or 64-bit signed integers depending on the platform. It's best to use `ParseUint` directly.

## Steps to reproduce

RPKI data:
```
{"roas":[{"prefix":"172.21.113.192/27","maxLength":29,"asn":"AS4242422911"}]}
```

On `x86_64`: 4242422911 :+1:
On `armv7l`: 2147483647 :-1: