### PR TITLE
update Compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Implementations on versions may vary.
 | Device/software | Plaintext | TLS | SSH | Notes             |
 | --------------- | --------- | --- | --- | ----------------- |
 | RTRdump         | Yes       | Yes | Yes |                   |
-| RTRlib          | Yes       | no  | Yes | Only SSH key      |
+| RTRlib          | Yes       | No  | Yes | Only SSH key      |
 | Juniper         | Yes       | No  | No  |                   |
 | Cisco           | Yes       | No  | Yes | Only SSH password |
 | Alcatel         | Yes       | No  | No  |                   |

--- a/README.md
+++ b/README.md
@@ -233,11 +233,12 @@ Implementations on versions may vary.
 | Device/software | Plaintext | TLS | SSH | Notes             |
 | --------------- | --------- | --- | --- | ----------------- |
 | RTRdump         | Yes       | Yes | Yes |                   |
+| RTRlib          | Yes       | no  | Yes | Only SSH key      |
 | Juniper         | Yes       | No  | No  |                   |
 | Cisco           | Yes       | No  | Yes | Only SSH password |
 | Alcatel         | Yes       | No  | No  |                   |
 | Arista          | No        | No  | No  |                   |
-| FRRouting       | Yes       | No  | Yes | Only SSH password |
+| FRRouting       | Yes       | No  | Yes | Only SSH key      |
 | Bird            | Yes       | No  | Yes | Only SSH key      |
 | Quagga          | Yes       | No  | No  |                   |
 


### PR DESCRIPTION
The Compatibility matrix is incomplete and includes an incorrect statement. This PR fix this.

It didn't mention RTRlib (https://github.com/rtrlib/rtrlib/), which is a C library implementing the RTR protocol. Part of the software package is the rtrclient, which dumps valid ROA payloads, similar to RTRdump.

RPKI support in FRRouting and BIRD is based on RTRlib. Currently, SSH transport in the RTRlib only allows for key-based authentication. As such, FRRouting does not support password-based SSH but key-based SSH.

Password-based SSH authentication will be available soon, see https://github.com/rtrlib/rtrlib/issues/250.