### PR TITLE
Filter and assertion implementation (#34)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ vet:
 .PHONY: test
 test:
 	go test -v github.com/cloudflare/gortr/lib
+	go test -v github.com/cloudflare/gortr/prefixfile
 
 .PHONY: prepare
 prepare:

--- a/prefixfile/prefixfile.go
+++ b/prefixfile/prefixfile.go
@@ -145,3 +145,11 @@ func (roa *ROAJson) GetMaxLen() int {
 func (roa *ROAJson) String() string {
 	return fmt.Sprintf("%v/%v/%v", roa.Prefix, roa.Length, roa.ASN)
 }
+
+func GetIPBroadcast(ipnet net.IPNet) net.IP {
+	br := make([]byte, len(ipnet.IP))
+	for i := 0; i < len(ipnet.IP); i++ {
+		br[i] = ipnet.IP[i] | (^ipnet.Mask[i])
+	}
+	return net.IP(br)
+}

--- a/prefixfile/slurm.go
+++ b/prefixfile/slurm.go
@@ -1,0 +1,161 @@
+package prefixfile
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+)
+
+type SlurmPrefixFilter struct {
+	Prefix  string
+	ASN     interface{}
+	Comment string
+}
+
+func (pf *SlurmPrefixFilter) GetASN() (uint32, bool) {
+	if pf.ASN == nil {
+		return 0, true
+	} else {
+		switch asn := pf.ASN.(type) {
+		case json.Number:
+			c, _ := asn.Int64()
+			return uint32(c), false
+		case uint32:
+			return asn, false
+		default:
+			return 0, true
+		}
+	}
+}
+
+func (pf *SlurmPrefixFilter) GetPrefix() *net.IPNet {
+	_, prefix, _ := net.ParseCIDR(pf.Prefix)
+	return prefix
+}
+
+type SlurmValidationOutputFilters struct {
+	PrefixFilters []SlurmPrefixFilter
+}
+
+type SlurmPrefixAssertion struct {
+	Prefix          string
+	ASN             uint32
+	MaxPrefixLength int
+	Comment         string
+}
+
+func (pa *SlurmPrefixAssertion) GetASN() uint32 {
+	return pa.ASN
+}
+
+func (pa *SlurmPrefixAssertion) GetPrefix() *net.IPNet {
+	_, prefix, _ := net.ParseCIDR(pa.Prefix)
+	return prefix
+}
+
+func (pa *SlurmPrefixAssertion) GetMaxLen() int {
+	return pa.MaxPrefixLength
+}
+
+type SlurmLocallyAddedAssertions struct {
+	PrefixAssertions []SlurmPrefixAssertion
+}
+
+type SlurmConfig struct {
+	SlurmVersion            int
+	ValidationOutputFilters SlurmValidationOutputFilters
+	LocallyAddedAssertions  SlurmLocallyAddedAssertions
+}
+
+func DecodeJSONSlurm(buf io.Reader) (*SlurmConfig, error) {
+	slurm := &SlurmConfig{}
+	dec := json.NewDecoder(buf)
+	dec.UseNumber()
+	err := dec.Decode(slurm)
+	if err != nil {
+		return nil, err
+	}
+	return slurm, nil
+}
+
+func (s *SlurmValidationOutputFilters) FilterOnROAs(roas []ROAJson) ([]ROAJson, []ROAJson) {
+	added := make([]ROAJson, 0)
+	removed := make([]ROAJson, 0)
+	if s.PrefixFilters == nil || len(s.PrefixFilters) == 0 {
+		return added, removed
+	}
+	for _, roa := range roas {
+		rPrefix := roa.GetPrefix()
+		var rIPStart net.IP
+		var rIPEnd net.IP
+		if rPrefix != nil {
+			rIPStart = rPrefix.IP.To16()
+			rIPEnd = GetIPBroadcast(*rPrefix).To16()
+		}
+
+		var wasRemoved bool
+		for _, filter := range s.PrefixFilters {
+			fPrefix := filter.GetPrefix()
+			fASN, fASNEmpty := filter.GetASN()
+			match := true
+			if match && fPrefix != nil && rPrefix != nil {
+
+				if !(fPrefix.Contains(rIPStart) && fPrefix.Contains(rIPEnd)) {
+					match = false
+				}
+			}
+			if match && !fASNEmpty {
+				if roa.GetASN() != fASN {
+					match = false
+				}
+			}
+			if match {
+				removed = append(removed, roa)
+				wasRemoved = true
+				break
+			}
+		}
+
+		if !wasRemoved {
+			added = append(added, roa)
+		}
+	}
+	return added, removed
+}
+
+func (s *SlurmConfig) FilterOnROAs(roas []ROAJson) ([]ROAJson, []ROAJson) {
+	return s.ValidationOutputFilters.FilterOnROAs(roas)
+}
+
+func (s *SlurmLocallyAddedAssertions) AssertROAs() []ROAJson {
+	roas := make([]ROAJson, 0)
+	if s.PrefixAssertions == nil || len(s.PrefixAssertions) == 0 {
+		return roas
+	}
+	for _, assertion := range s.PrefixAssertions {
+		prefix := assertion.GetPrefix()
+		size, _ := prefix.Mask.Size()
+		maxLength := assertion.MaxPrefixLength
+		if assertion.MaxPrefixLength <= size {
+			maxLength = size
+		}
+		roas = append(roas, ROAJson{
+			ASN:    fmt.Sprintf("AS%v", assertion.ASN),
+			Prefix: assertion.Prefix,
+			Length: uint8(maxLength),
+			TA:     assertion.Comment,
+		})
+	}
+	return roas
+}
+
+func (s *SlurmConfig) AssertROAs() []ROAJson {
+	return s.LocallyAddedAssertions.AssertROAs()
+}
+
+func (s *SlurmConfig) FilterAssert(roas []ROAJson) []ROAJson {
+	a, _ := s.FilterOnROAs(roas)
+	b := s.AssertROAs()
+	return append(a, b...)
+}

--- a/prefixfile/slurm_test.go
+++ b/prefixfile/slurm_test.go
@@ -1,0 +1,143 @@
+package prefixfile
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDecodeJSON(t *testing.T) {
+	data := `{
+		  "slurmVersion": 1,
+		  "validationOutputFilters": {
+		   "prefixFilters": [
+		     {
+		      "prefix": "192.0.2.0/24",
+		      "comment": "All VRPs encompassed by prefix"
+		     },
+		     {
+		      "asn": 64496,
+		      "comment": "All VRPs matching ASN"
+		     },
+		     {
+		      "prefix": "198.51.100.0/24",
+		      "asn": 64497,
+		      "comment": "All VRPs encompassed by prefix, matching ASN"
+		     }
+		   ],
+		   "bgpsecFilters": [
+		     {
+		      "asn": 64496,
+		      "comment": "All keys for ASN"
+		     },
+		     {
+		      "SKI": "Zm9v",
+		      "comment": "Key matching Router SKI"
+		     },
+		     {
+		      "asn": 64497,
+		      "SKI": "YmFy",
+		      "comment": "Key for ASN 64497 matching Router SKI"
+		     }
+		   ]
+		  },
+		  "locallyAddedAssertions": {
+		   "prefixAssertions": [
+		     {
+		      "asn": 64496,
+		      "prefix": "198.51.100.0/24",
+		      "comment": "My other important route"
+		     },
+		     {
+		      "asn": 64496,
+		      "prefix": "2001:DB8::/32",
+		      "maxPrefixLength": 48,
+		      "comment": "My other important de-aggregated routes"
+		     }
+		   ],
+		   "bgpsecAssertions": [
+		     {
+		      "asn": 64496,
+		      "comment" : "My known key for my important ASN",
+		      "SKI": "<some base64 SKI>",
+		      "routerPublicKey": "<some base64 public key>"
+		     }
+		   ]
+		  }
+		}`
+	buf := bytes.NewBufferString(data)
+	decoded, err := DecodeJSONSlurm(buf)
+	assert.Nil(t, err)
+	asn, _ := decoded.ValidationOutputFilters.PrefixFilters[1].GetASN()
+	_, asnEmpty := decoded.ValidationOutputFilters.PrefixFilters[0].GetASN()
+	assert.Equal(t, uint32(64496), asn)
+	assert.True(t, asnEmpty)
+	assert.Equal(t, "192.0.2.0/24", decoded.ValidationOutputFilters.PrefixFilters[0].Prefix)
+}
+
+func TestFilterOnROAs(t *testing.T) {
+	roas := []ROAJson{
+		ROAJson{
+			ASN:    "AS65001",
+			Prefix: "192.168.0.0/25",
+			Length: 25,
+		},
+		ROAJson{
+			ASN:    "AS65002",
+			Prefix: "192.168.1.0/24",
+			Length: 24,
+		},
+		ROAJson{
+			ASN:    "AS65003",
+			Prefix: "192.168.2.0/24",
+			Length: 24,
+		},
+		ROAJson{
+			ASN:    "AS65004",
+			Prefix: "10.0.0.0/24",
+			Length: 24,
+		},
+	}
+
+	slurm := SlurmValidationOutputFilters{
+		PrefixFilters: []SlurmPrefixFilter{
+			SlurmPrefixFilter{
+				Prefix: "10.0.0.0/8",
+			},
+			SlurmPrefixFilter{
+				ASN:    uint32(65001),
+				Prefix: "192.168.0.0/24",
+			},
+			SlurmPrefixFilter{
+				ASN: uint32(65002),
+			},
+		},
+	}
+	added, removed := slurm.FilterOnROAs(roas)
+	assert.Len(t, added, 1)
+	assert.Len(t, removed, 3)
+	assert.Equal(t, uint32(65001), removed[0].GetASN())
+}
+
+func TestAssertROAs(t *testing.T) {
+	slurm := SlurmLocallyAddedAssertions{
+		PrefixAssertions: []SlurmPrefixAssertion{
+			SlurmPrefixAssertion{
+				ASN:     uint32(65001),
+				Prefix:  "10.0.0.0/8",
+				Comment: "Hello",
+			},
+			SlurmPrefixAssertion{
+				ASN:    uint32(65001),
+				Prefix: "192.168.0.0/24",
+			},
+			SlurmPrefixAssertion{
+				ASN:             uint32(65003),
+				Prefix:          "192.168.0.0/25",
+				MaxPrefixLength: 26,
+			},
+		},
+	}
+	roas := slurm.AssertROAs()
+	assert.Len(t, roas, 3)
+}


### PR DESCRIPTION
* Possibility to read a slurm file (rfc8416) from an http/https endpoint or from a file
* Filters prefixes and adds new ones contained in the configuration
* Can output a new rpki.json which contains the updated prefixes and sign it (other GoRTR can consome from it)