### PR TITLE
Fix potential panic risk for #36

### DIFF
--- a/cmd/gortr/gortr.go
+++ b/cmd/gortr/gortr.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -211,10 +210,16 @@ func processData(roalistjson *prefixfile.ROAList) ([]rtr.ROA, int, int, int) {
 	var countv4 int
 	var countv6 int
 	for _, v := range roalistjson.Data {
-		_, prefix, _ := net.ParseCIDR(v.Prefix)
-		asnStr := v.ASN[2:len(v.ASN)]
-		asnInt, _ := strconv.ParseUint(asnStr, 10, 32)
-		asn := uint32(asnInt)
+		prefix, err := v.GetPrefix2()
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+		asn, err := v.GetASN2()
+		if err != nil {
+			log.Error(err)
+			continue
+		}
 
 		count++
 		if prefix.IP.To4() != nil {


### PR DESCRIPTION
Changes the ROA decoder
```
{
  "roas": [
    {
      "prefix": "10.0.0.0/24",
      "asn": 65001,
      "maxLength": 24
    },
    {
      "prefix": "10.0.0.0/24",
      "asn": "AS65002",
      "maxLength": 24
    },
    {
      "prefix": "10.0.0.0/24",
      "maxLength": 24
    },
    {
      "prefix": "10.0.0.0/24",
      "asn": "65003.1123",
      "maxLength": 24
    },
    {
      "prefix": "10.0.0.0/24",
      "asn": 65004.1123,
      "maxLength": 24
    }
  ]
}
```
The following file will cause errors instead of a panic:

```
ERRO[0000] Could not decode ASN: <nil> as part of ROA
ERRO[0000] Could not decode ASN: 65003.1123 as part of ROA
DEBU[0000] Computed diff: added ([ROA 10.0.0.0/24 -> /24, AS65001, Flags: 1 ROA 10.0.0.0/24 -> /24, AS65002, Flags: 1 ROA 10.0.0.0/24 -> /24, AS65004, Flags: 1]), removed ([]), unchanged ([])
```