### PR TITLE
README: Update Compatibility matrix (Line 302)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Implementations on versions may vary.
 | Alcatel         | Yes       | No  | No  |                   |
 | Arista          | No        | No  | No  |                   |
 | FRRouting       | Yes       | No  | Yes | Only SSH key      |
-| Bird            | Yes       | No  | Yes | Only SSH key      |
+| Bird2           | Yes       | No  | Yes | Only SSH key      |
 | Quagga          | Yes       | No  | No  |                   |
 
 ### Configure on Juniper


### PR DESCRIPTION
Change 'Bird' to 'Bird2'. Bird version < 2 does not support connecting to ROA
cert publishers. (E.g. gortr, routinator, etc.)