### PR TITLE
Options to set session ID and timers via CLI #52

### DIFF
--- a/lib/server.go
+++ b/lib/server.go
@@ -146,7 +146,7 @@ type ServerConfiguration struct {
 func NewServer(configuration ServerConfiguration, handler RTRServerEventHandler, simpleHandler RTREventHandler) *Server {
 	var sessid uint16
 	if configuration.SessId < 0 {
-		GenerateSessionId()
+		sessid = GenerateSessionId()
 	} else {
 		sessid = uint16(configuration.SessId)
 	}


### PR DESCRIPTION
* Also fixes a session ID bug where the variable was never random
* Introduces the following flags: `rtr.sessionid`. `rtr.refresh`, `rtr.retry` and `rtr.expire`

Resolves issue #52 