### PR TITLE
Add message logging for RTRdump (option to skip data PDUs)

### DIFF
--- a/cmd/gortr/gortr.go
+++ b/cmd/gortr/gortr.go
@@ -94,8 +94,9 @@ var (
 	Slurm        = flag.String("slurm", "", "Slurm configuration file (filters and assertions)")
 	SlurmRefresh = flag.Bool("slurm.refresh", true, "Refresh along the cache")
 
-	LogLevel = flag.String("loglevel", "info", "Log level")
-	Version  = flag.Bool("version", false, "Print version")
+	LogLevel   = flag.String("loglevel", "info", "Log level")
+	LogVerbose = flag.Bool("log.verbose", false, "Additional debug logs")
+	Version    = flag.Bool("version", false, "Print version")
 
 	NumberOfROAs = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -635,6 +636,7 @@ func main() {
 		SessId:          *SessionID,
 		KeepDifference:  3,
 		Log:             log.StandardLogger(),
+		LogVerbose:      *LogVerbose,
 
 		RefreshInterval: uint32(*RefreshRTR),
 		RetryInterval:   uint32(*RetryRTR),

--- a/lib/server.go
+++ b/lib/server.go
@@ -67,7 +67,7 @@ func (e *DefaultRTREventHandler) RequestCache(c *Client) {
 		} else {
 			c.SendROAs(sessionId, serial, roas)
 			if e.Log != nil {
-				e.Log.Debugf("%v < Sent ROAs (current serial %v)", c, serial)
+				e.Log.Debugf("%v < Sent ROAs (current serial %d, session: %d)", c, serial, sessionId)
 			}
 		}
 	}
@@ -93,7 +93,7 @@ func (e *DefaultRTREventHandler) RequestNewVersion(c *Client, sessionId uint16, 
 		} else {
 			c.SendROAs(sessionId, serial, roas)
 			if e.Log != nil {
-				e.Log.Debugf("%v < Sent ROAs (current serial %v)", c, serial)
+				e.Log.Debugf("%v < Sent ROAs (current serial %d, session from client: %d)", c, serial, sessionId)
 			}
 		}
 	}
@@ -126,7 +126,8 @@ type Server struct {
 	pduRetryInterval   uint32
 	pduExpireInterval  uint32
 
-	log Logger
+	log        Logger
+	logverbose bool
 }
 
 type ServerConfiguration struct {
@@ -141,7 +142,8 @@ type ServerConfiguration struct {
 	RetryInterval   uint32
 	ExpireInterval  uint32
 
-	Log Logger
+	Log        Logger
+	LogVerbose bool
 }
 
 func NewServer(configuration ServerConfiguration, handler RTRServerEventHandler, simpleHandler RTREventHandler) *Server {
@@ -186,7 +188,8 @@ func NewServer(configuration ServerConfiguration, handler RTRServerEventHandler,
 		pduRetryInterval:   retryInterval,
 		pduExpireInterval:  expireInterval,
 
-		log: configuration.Log,
+		log:        configuration.Log,
+		logverbose: configuration.LogVerbose,
 	}
 }
 
@@ -347,8 +350,10 @@ func (s *Server) AddROAs(roas []ROA) {
 	roaCurrent := s.roaCurrent
 
 	added, removed, unchanged := ComputeDiff(roas, roaCurrent)
-	if s.log != nil {
+	if s.log != nil && s.logverbose {
 		s.log.Debugf("Computed diff: added (%v), removed (%v), unchanged (%v)", added, removed, unchanged)
+	} else if s.log != nil {
+		s.log.Debugf("Computed diff: added (%d), removed (%d), unchanged (%d)", len(added), len(removed), len(unchanged))
 	}
 	curDiff = append(added, removed...)
 	s.roalock.RUnlock()


### PR DESCRIPTION
```
$ ./rtrdump -loglevel debug -connect rtr.rpki.cloudflare.com:8282
INFO[0000] Connecting with plain to rtr.rpki.cloudflare.com:8282
DEBU[0000] Received: PDU Cache Response v1 (session: 30068)
DEBU[0002] Received: PDU End of Data v1 (session: 30068): serial: 555, refresh: 3600, retry: 600, expire: 7200
```