### PR TITLE
fix debian packaging bug with no default config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ package-deb-gortr: prepare
         --url "$(URL)" \
         --architecture $(ARCH) \
         --license "$(LICENSE)" \
-        --deb-no-default-config-files \
         --package $(DIST_DIR) \
         $(OUTPUT_GORTR)=/usr/bin/gortr \
         package/gortr.service=/lib/systemd/system/gortr.service \


### PR DESCRIPTION
would erase default configuration file without it.