### PR TITLE
Always expose rpki_refresh metrics for sucessful http calls

### DIFF
--- a/cmd/rtrmon/rtrmon.go
+++ b/cmd/rtrmon/rtrmon.go
@@ -7,13 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	rtr "github.com/cloudflare/gortr/lib"
-	"github.com/cloudflare/gortr/prefixfile"
-	"github.com/cloudflare/gortr/utils"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -22,6 +15,14 @@ import (
 	"runtime"
 	"sync"
 	"time"
+
+	rtr "github.com/cloudflare/gortr/lib"
+	"github.com/cloudflare/gortr/prefixfile"
+	"github.com/cloudflare/gortr/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
 )
 
 const (
@@ -264,7 +265,7 @@ func (c *Client) Start(id int, ch chan int) {
 			}
 		} else {
 			log.Infof("%d: Fetching %s", c.id, c.Path)
-			data, _, _, err := c.FetchConfig.FetchFile(c.Path)
+			data, _, err := c.FetchConfig.FetchFile(c.Path)
 			if err != nil {
 				log.Error(err)
 				continue


### PR DESCRIPTION
For successful HTTP calls there were cases where no `rpki_refresh` metric was exposed, as `FetchFile()` return'ed without the bool return value set to true.

As the bool return value mainly seems to indicate that a file was successfully fetch from an HTTP URL, the same behavior can be achieve by using the HTTP status code to expose the metric.

This also contains some drive-by clean-ups.