### PR TITLE
utils: fix dropped error

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -73,6 +73,9 @@ func (c *FetchConfig) FetchFile(file string) ([]byte, int, error) {
 
 		client := &http.Client{Transport: tr}
 		req, err := http.NewRequest("GET", file, nil)
+		if err != nil {
+			return nil, -1, err
+		}
 		req.Header.Set("User-Agent", c.UserAgent)
 		if c.Mime != "" {
 			req.Header.Set("Accept", c.Mime)


### PR DESCRIPTION
This fixes a dropped `err` variable in the `utils` package.