### PR TITLE
NETSYS-264 Deprecate GoRTR in favour of StayRTR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GoRTR
 
+## DEPRECATION NOTICE
+**This software is no longer maintained. We advise replacing your production use of this software with the swap-in replacement [StayRTR](https://github.com/bgp/stayrtr)**
+
 [![Build Status](https://github.com/cloudflare/gortr/workflows/Go/badge.svg)](https://github.com/cloudflare/gortr/actions?query=workflow%3AGo)
 [![GoDoc](https://godoc.org/github.com/cloudflare/gortr?status.svg)](https://pkg.go.dev/github.com/cloudflare/gortr)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/cloudflare/gortr)


### PR DESCRIPTION
GoRTR is no longer actively maintained. As such we're deprecating.